### PR TITLE
removed hover resize effect from connect button

### DIFF
--- a/src/components/connect-wallet/ConnectWallet.scss
+++ b/src/components/connect-wallet/ConnectWallet.scss
@@ -36,6 +36,7 @@ div.connectWallet {
 
       &:hover {
         cursor: pointer;
+        background-color: var(--chakra-colors-purple-200);
       }
     }
 

--- a/src/components/connect-wallet/ConnectWallet.scss
+++ b/src/components/connect-wallet/ConnectWallet.scss
@@ -36,8 +36,6 @@ div.connectWallet {
 
       &:hover {
         cursor: pointer;
-        padding: 15px;
-        border: 2px solid var(--text-selected);
       }
     }
 

--- a/src/components/connect-wallet/ConnectWallet.scss
+++ b/src/components/connect-wallet/ConnectWallet.scss
@@ -23,8 +23,8 @@ div.connectWallet {
     padding: 32px;
 
     & > button {
-      background: $primary;
-      color: var(--background-main);
+      background: $primary-shade;
+      color: var(--text);
       outline: none;
 
       border-radius: 10px;
@@ -36,8 +36,7 @@ div.connectWallet {
 
       &:hover {
         cursor: pointer;
-        background-color: $secondary-focus;
-        color: var(--text);
+        background-color: #050422;
         box-shadow: var(--shadow-hover);
       }
     }

--- a/src/components/connect-wallet/ConnectWallet.scss
+++ b/src/components/connect-wallet/ConnectWallet.scss
@@ -23,8 +23,8 @@ div.connectWallet {
     padding: 32px;
 
     & > button {
-      background: $primary-shade;
-      color: var(--text);
+      background: $primary;
+      color: var(--background-main);
       outline: none;
 
       border-radius: 10px;
@@ -36,7 +36,9 @@ div.connectWallet {
 
       &:hover {
         cursor: pointer;
-        background-color: var(--chakra-colors-purple-200);
+        background-color: $secondary-focus;
+        color: var(--text);
+        box-shadow: var(--shadow-hover);
       }
     }
 


### PR DESCRIPTION
There is no longer any resizing done on hover for the connect wallet buttons.

I left the pointer property on hover because it felt appropriate, but I'll ask around and see if we want to replace this effect with a different one.

**Before this PR:**

Default:

<img width="567" alt="image" src="https://user-images.githubusercontent.com/23615754/141830629-4443a35a-97c8-44b5-8e68-f715fccda31b.png">

Hover:

<img width="565" alt="image" src="https://user-images.githubusercontent.com/23615754/141830674-0fab37eb-6e86-4842-a24d-1eb09527e1dd.png">

**After PR:**

Hover:

<img width="566" alt="image" src="https://user-images.githubusercontent.com/23615754/141830759-3bfd17e4-e8ac-4cd2-ac0e-311de97f02fe.png">

(i.e. notice that there is no difference except the pointer, which you can't see in this screenshot)

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1201356688521654